### PR TITLE
Add encoding and decoding of item details (quantity/skin/upgrades)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ import {encode, decode} from 'gw2e-chat-codes'
 
 // Encode a type and id as a chat code
 // Valid types are item, map, skill, trait, recipe, skin & outfit
-let encodedCode = encode('item', 46762)
-// -> '[&AgGqtgAA]'
+let encodedSkill = encode('skill', 5842)
+// -> '[&BtIWAAA=]'
+
+// You can pass an object as second parameter to also encode quantity, skin or upgrades
+let encodedItem = encode('item', {id: 46762, quantity: 10, skin: 5807, upgrades: [24554, 24615]})
+// -> '[&AgGqtgDgrxYAAOpfAAAnYAAA]'
 
 // Decode a chat code into type and id
 let decodedCode = decode('[&BtIWAAA=]')

--- a/src/index.js
+++ b/src/index.js
@@ -9,36 +9,93 @@ const codeTypes = {
   outfit: 0x0B
 }
 
+const itemFlags = {
+  skin: 0x80,
+  upgrade1: 0x40,
+  upgrade2: 0x20
+}
+
 export default {encode, decode}
 
-export function encode (type, id) {
-  // Grab the right type id
+export function encode (type, info) {
+  // Get the type
   type = codeTypeByName(type)
-  id = parseInt(id, 10)
+
+  // Normalize the info object if only the id was passed
+  if (!info || !info.id) {
+    info = {id: info}
+  }
+
+  // Grab the right type id
+  const id = parseInt(info.id, 10)
 
   // Make sure the type and id are valid
   if (!type || isNaN(id) || id < 0) {
     return false
   }
 
-  // Encode the ID as a 4-byte little endian integer, then a null byte as terminator
-  let data = []
-  while (id > 0) {
-    data.push(id & 255)
-    id = id >> 8
-  }
-
-  while (data.length < 4 || data.length % 2 !== 0) {
-    data.push(0)
-  }
+  // Add the type header byte at the start of the data
+  const data = [type]
 
   // The quantity of items is encoded as a single byte before the id bytes
-  if (type === 2) {
-    data.unshift(1)
+  if (type === codeTypes.item) {
+    data.push(info.quantity || 1)
   }
 
-  // Add the type header byte at the start of the data
-  data.unshift(type)
+  // Encode the ID as a 3-byte little endian integer
+  write3Bytes(data, id)
+
+  // Encode item details
+  if (type === codeTypes.item) {
+    let flags = 0
+
+    // Get the skin and upgrades as integer
+    const skin = parseInt(info.skin, 10)
+    const upgrade1 = parseInt(info.upgrade1, 10)
+    const upgrade2 = parseInt(info.upgrade2, 10)
+
+    // Check which flags should be set
+    const hasSkin = !isNaN(skin)
+    const hasUpgrade1 = !isNaN(upgrade1)
+    const hasUpgrade2 = !isNaN(upgrade2)
+
+    // Add the flags
+    if (hasSkin) {
+      flags |= itemFlags.skin
+    }
+
+    if (hasUpgrade1) {
+      flags |= itemFlags.upgrade1
+    }
+
+    if (hasUpgrade2) {
+      flags |= itemFlags.upgrade2
+    }
+
+    // Encode the flags
+    data.push(flags)
+
+    // Encode the skin id
+    if (hasSkin) {
+      write3Bytes(data, skin)
+      data.push(0x00)
+    }
+
+    // Encode the first upgrade slot
+    if (hasUpgrade1) {
+      write3Bytes(data, upgrade1)
+      data.push(0x00)
+    }
+
+    // Encode the second upgrade slot
+    if (hasUpgrade2) {
+      write3Bytes(data, upgrade2)
+      data.push(0x00)
+    }
+  } else {
+    // Add null byte as terminator
+    data.push(0x00)
+  }
 
   // Convert to binary
   let base = base64.fromByteArray(data)
@@ -57,23 +114,67 @@ export function decode (chatcode) {
   let base = chatcode.slice(2, chatcode.length - 1)
   let data = base64.toByteArray(base)
 
-  // Get the type key
-  let type = codeTypeById(data[0])
+  // Pointer to the current byte we are reading
+  let offset = 0
+
+  // Get the type
+  const type = data[offset++]
+
+  // Object with decoded data
+  const decoded = {
+    type: codeTypeById(type)
+  }
 
   // Invalid type
-  if (type === undefined) {
+  if (decoded.type === undefined) {
     return false
   }
 
-  // Set the byte offset, which is the header for most types
-  // and the header + quantity for item types
-  let offset = type === 'item' ? 2 : 1
+  // Read the quantity for items
+  if (type === codeTypes.item) {
+    decoded.quantity = data[offset++]
+  }
 
   // Get the id out of the non-header bytes
-  let id = data[offset] | data[offset + 1] << 8 | data[offset + 2] << 16
+  decoded.id = data[offset++] | data[offset++] << 8 | data[offset++] << 16
+
+  // Read more item details
+  if (type === codeTypes.item) {
+    const flags = data[offset++]
+
+    // Skin
+    if ((flags & itemFlags.skin) === itemFlags.skin) {
+      decoded.skin = data[offset++] | data[offset++] << 8 | data[offset++] << 16
+
+      // skip next byte (always 0x00)
+      offset++
+    }
+
+    // Upgrade slot 1
+    if ((flags & itemFlags.upgrade1) === itemFlags.upgrade1) {
+      decoded.upgrade1 = data[offset++] | data[offset++] << 8 | data[offset++] << 16
+
+      // skip next byte (always 0x00)
+      offset++
+    }
+
+    // Upgrade slot 2
+    if ((flags & itemFlags.upgrade2) === itemFlags.upgrade2) {
+      decoded.upgrade2 = data[offset++] | data[offset++] << 8 | data[offset++] << 16
+
+      // skip next byte (always 0x00)
+      offset++
+    }
+  }
 
   // Return the decoded chat code
-  return {type: type, id: id}
+  return decoded
+}
+
+function write3Bytes (data, value) {
+  data.push((value >> 0x00) & 0xFF)
+  data.push((value >> 0x08) & 0xFF)
+  data.push((value >> 0x10) & 0xFF)
 }
 
 function codeTypeByName (name) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,8 @@ export function encode (type, info) {
 
     // Get the skin and upgrades as integer
     const skin = parseInt(info.skin, 10)
-    const upgrade1 = parseInt(info.upgrade1, 10)
-    const upgrade2 = parseInt(info.upgrade2, 10)
+    const upgrade1 = info.upgrades && parseInt(info.upgrades[0], 10)
+    const upgrade2 = info.upgrades && parseInt(info.upgrades[1], 10)
 
     // Check which flags should be set
     const hasSkin = !isNaN(skin)
@@ -152,7 +152,7 @@ export function decode (chatcode) {
 
     // Upgrade slot 1
     if ((flags & itemFlags.upgrade1) === itemFlags.upgrade1) {
-      decoded.upgrade1 = data[offset++] | data[offset++] << 8 | data[offset++] << 16
+      decoded.upgrades = [data[offset++] | data[offset++] << 8 | data[offset++] << 16]
 
       // skip next byte (always 0x00)
       offset++
@@ -160,7 +160,7 @@ export function decode (chatcode) {
 
     // Upgrade slot 2
     if ((flags & itemFlags.upgrade2) === itemFlags.upgrade2) {
-      decoded.upgrade2 = data[offset++] | data[offset++] << 8 | data[offset++] << 16
+      decoded.upgrades[1] = data[offset++] | data[offset++] << 8 | data[offset++] << 16
 
       // skip next byte (always 0x00)
       offset++

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -3,7 +3,6 @@ import {expect} from 'chai'
 import codes from '../src/index.js'
 
 const testCases = [
-  {type: 'item', id: 46762, code: '[&AgGqtgAA]'},
   {type: 'map', id: 825, code: '[&BDkDAAA=]'},
   {type: 'skill', id: 5842, code: '[&BtIWAAA=]'},
   {type: 'trait', id: 1010, code: '[&B/IDAAA=]'},
@@ -12,10 +11,29 @@ const testCases = [
   {type: 'outfit', id: 28, code: '[&CxwAAAA=]'}
 ]
 
+const itemTestCases = [
+  {type: 'item', info: {id: 46762}, code: '[&AgGqtgAA]'},
+  {type: 'item', info: {id: 46762, quantity: 42}, code: '[&AiqqtgAA]'},
+  {type: 'item', info: {id: 46762, upgrade1: 24575}, code: '[&AgGqtgBA/18AAA==]'},
+  {type: 'item', info: {id: 46762, upgrade1: 24575, upgrade2: 24615}, code: '[&AgGqtgBg/18AACdgAAA=]'},
+  {type: 'item', info: {id: 46762, skin: 3709}, code: '[&AgGqtgCAfQ4AAA==]'},
+  {type: 'item', info: {id: 46762, skin: 3709, upgrade1: 24575}, code: '[&AgGqtgDAfQ4AAP9fAAA=]'},
+  {type: 'item', info: {id: 46762, skin: 3709, upgrade1: 24575, upgrade2: 24615}, code: '[&AgGqtgDgfQ4AAP9fAAAnYAAA]'},
+  {type: 'item', info: {id: 46762, quantity: 42, skin: 3709, upgrade1: 24575, upgrade2: 24615}, code: '[&AiqqtgDgfQ4AAP9fAAAnYAAA]'}
+]
+
 describe('encoding', () => {
   testCases.map(test => {
     it('encodes ' + test.type + ' chat codes correctly', () => {
       expect(codes.encode(test.type, test.id)).to.equal(test.code)
+    })
+  })
+
+  it('encodes item chat codes correctly', () => {
+    expect(codes.encode('item', 46762)).to.equal('[&AgGqtgAA]')
+
+    itemTestCases.map(test => {
+      expect(codes.encode(test.type, test.info)).to.equal(test.code)
     })
   })
 
@@ -26,6 +44,9 @@ describe('encoding', () => {
   it('fails gracefully for a invalid id', () => {
     expect(codes.encode('item', '#notanid')).to.equal(false)
     expect(codes.encode('item', -5)).to.equal(false)
+    expect(codes.encode('item', {})).to.equal(false)
+    expect(codes.encode('item', {id: '#notanid'})).to.equal(false)
+    expect(codes.encode('item', {id: -5})).to.equal(false)
   })
 })
 
@@ -33,6 +54,12 @@ describe('decoding', () => {
   testCases.map(test => {
     it('decodes ' + test.type + ' chat codes correctly', () => {
       expect(codes.decode(test.code)).to.deep.equal({type: test.type, id: test.id})
+    })
+  })
+
+  it('decodes item chat codes correctly', () => {
+    itemTestCases.map(test => {
+      expect(codes.decode(test.code)).to.deep.equal({type: test.type, quantity: 1, ...test.info})
     })
   })
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -14,12 +14,12 @@ const testCases = [
 const itemTestCases = [
   {type: 'item', info: {id: 46762}, code: '[&AgGqtgAA]'},
   {type: 'item', info: {id: 46762, quantity: 42}, code: '[&AiqqtgAA]'},
-  {type: 'item', info: {id: 46762, upgrade1: 24575}, code: '[&AgGqtgBA/18AAA==]'},
-  {type: 'item', info: {id: 46762, upgrade1: 24575, upgrade2: 24615}, code: '[&AgGqtgBg/18AACdgAAA=]'},
+  {type: 'item', info: {id: 46762, upgrades: [24575]}, code: '[&AgGqtgBA/18AAA==]'},
+  {type: 'item', info: {id: 46762, upgrades: [24575, 24615]}, code: '[&AgGqtgBg/18AACdgAAA=]'},
   {type: 'item', info: {id: 46762, skin: 3709}, code: '[&AgGqtgCAfQ4AAA==]'},
-  {type: 'item', info: {id: 46762, skin: 3709, upgrade1: 24575}, code: '[&AgGqtgDAfQ4AAP9fAAA=]'},
-  {type: 'item', info: {id: 46762, skin: 3709, upgrade1: 24575, upgrade2: 24615}, code: '[&AgGqtgDgfQ4AAP9fAAAnYAAA]'},
-  {type: 'item', info: {id: 46762, quantity: 42, skin: 3709, upgrade1: 24575, upgrade2: 24615}, code: '[&AiqqtgDgfQ4AAP9fAAAnYAAA]'}
+  {type: 'item', info: {id: 46762, skin: 3709, upgrades: [24575]}, code: '[&AgGqtgDAfQ4AAP9fAAA=]'},
+  {type: 'item', info: {id: 46762, skin: 3709, upgrades: [24575, 24615]}, code: '[&AgGqtgDgfQ4AAP9fAAAnYAAA]'},
+  {type: 'item', info: {id: 46762, quantity: 42, skin: 3709, upgrades: [24575, 24615]}, code: '[&AiqqtgDgfQ4AAP9fAAAnYAAA]'}
 ]
 
 describe('encoding', () => {
@@ -35,6 +35,19 @@ describe('encoding', () => {
     itemTestCases.map(test => {
       expect(codes.encode(test.type, test.info)).to.equal(test.code)
     })
+  })
+
+  it('encodes item stacks from the API correctly', () => {
+    expect(codes.encode('item', {
+      'id': 46762,
+      'slot': 'WeaponA1',
+      'upgrades': [
+        24554,
+        24615
+      ],
+      'skin': 5807,
+      'binding': 'Account'
+    })).to.equal('[&AgGqtgDgrxYAAOpfAAAnYAAA]')
   })
 
   it('fails gracefully for a invalid type', () => {


### PR DESCRIPTION
`encode` now takes an object (`{id, quantity?, skin?, upgrade1?, upgrade2?}`) as second argument to pass the additional item info. Just passing the id still works.

`decode` will now always return `quantity` for items, and optional `skin`, `upgrade1` or `upgrade2`.